### PR TITLE
[ENH] Fix argument types in argparser

### DIFF
--- a/aroma/cli/__init__.py
+++ b/aroma/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line interfaces for AROMA."""

--- a/aroma/cli/aroma.py
+++ b/aroma/cli/aroma.py
@@ -38,12 +38,14 @@ def _get_parser():
         "-i",
         "-in",
         dest="inFile",
+        type=lambda x: is_valid_file(parser, x),
         required=False,
         help="Input file name of fMRI data (.nii.gz)",
     )
     nonfeatoptions.add_argument(
         "-mc",
         dest="mc",
+        type=lambda x: is_valid_file(parser, x),
         required=False,
         help=(
             "File name of the motion parameters obtained after motion "
@@ -56,6 +58,7 @@ def _get_parser():
         "-a",
         "-affmat",
         dest="affmat",
+        type=lambda x: is_valid_file(parser, x),
         default=None,
         help=(
             "File name of the mat-file describing the affine registration "
@@ -68,6 +71,7 @@ def _get_parser():
         "-w",
         "-warp",
         dest="warp",
+        type=lambda x: is_valid_file(parser, x),
         default=None,
         help=(
             "File name of the warp-file describing the non-linear "
@@ -80,6 +84,7 @@ def _get_parser():
         "-m",
         "-mask",
         dest="mask",
+        type=lambda x: is_valid_file(parser, x),
         default=None,
         help=(
             "File name of the mask to be used for MELODIC (denoising will be "
@@ -94,6 +99,7 @@ def _get_parser():
         "-feat",
         dest="inFeat",
         required=False,
+        type=lambda x: is_valid_path(parser, x),
         help=(
             "Feat directory name (Feat should have been run without temporal "
             "filtering and including registration to MNI152)"
@@ -107,6 +113,7 @@ def _get_parser():
         "-den",
         dest="denType",
         default="nonaggr",
+        choices=["nonaggr", "aggr", "both", "no"],
         help=(
             "Type of denoising strategy: 'no': only classification, no "
             "denoising; 'nonaggr': non-aggresssive denoising (default); "
@@ -118,6 +125,7 @@ def _get_parser():
         "-md",
         "-meldir",
         dest="melDir",
+        type=lambda x: is_valid_path(parser, x),
         default="",
         help=(
             "MELODIC directory name, in case MELODIC has been run previously."

--- a/aroma/cli/aroma.py
+++ b/aroma/cli/aroma.py
@@ -2,6 +2,7 @@
 import argparse
 
 from aroma import aroma
+from aroma.cli.parser_utils import is_valid_file, is_valid_path
 
 
 def _get_parser():
@@ -46,17 +47,16 @@ def _get_parser():
         required=False,
         help=(
             "File name of the motion parameters obtained after motion "
-            "realignment (e.g., FSL mcflirt). Note that the order of "
+            "realignment (e.g., FSL MCFLIRT). Note that the order of "
             "parameters does not matter, should your file not originate "
-            "from FSL mcflirt. (e.g., "
-            "/home/user/PROJECT/SUBJECT.feat/mc/prefiltered_func_data_mcf.par"
+            "from FSL MCFLIRT."
         ),
     )
     nonfeatoptions.add_argument(
         "-a",
         "-affmat",
         dest="affmat",
-        default="",
+        default=None,
         help=(
             "File name of the mat-file describing the affine registration "
             "(e.g., FSL FLIRT) of the functional data to structural space "
@@ -68,7 +68,7 @@ def _get_parser():
         "-w",
         "-warp",
         dest="warp",
-        default="",
+        default=None,
         help=(
             "File name of the warp-file describing the non-linear "
             "registration (e.g., FSL FNIRT) of the structural data to MNI152 "
@@ -80,7 +80,7 @@ def _get_parser():
         "-m",
         "-mask",
         dest="mask",
-        default="",
+        default=None,
         help=(
             "File name of the mask to be used for MELODIC (denoising will be "
             "performed on the original/non-masked input data)"

--- a/aroma/cli/parser_utils.py
+++ b/aroma/cli/parser_utils.py
@@ -1,0 +1,22 @@
+"""Utility functions for CLI parsers."""
+import os.path as op
+
+
+def is_valid_file(parser, arg):
+    """
+    Check if argument is existing file.
+    """
+    if not op.isfile(arg) and arg is not None:
+        parser.error('The file {0} does not exist!'.format(arg))
+
+    return arg
+
+
+def is_valid_path(parser, arg):
+    """
+    Check if argument is existing directory.
+    """
+    if not op.isdir(arg) and arg is not None:
+        parser.error('The folder {0} does not exist!'.format(arg))
+
+    return arg

--- a/aroma/tests/test_integration.py
+++ b/aroma/tests/test_integration.py
@@ -1,11 +1,8 @@
 import numpy as np
-import os
 import pandas as pd
-import subprocess
 from os.path import join, split, isfile
-from argparse import Namespace
 
-from aroma import main
+from aroma.aroma import aroma_workflow
 
 import pytest
 
@@ -24,10 +21,13 @@ def test_integration(skip_integration, nilearn_data):
     mc_path = join(test_path, 'mc.tsv')
     mc.to_csv(mc_path, sep='\t', index=False, header=None)
 
-    args = Namespace(TR=2, affmat='', denType='nonaggr', dim=0, generate_plots=False, inFeat=None, inFile=nilearn_data.func[0], mask='',
-                     mc=mc_path, melDir='', outDir=out_path, overwrite=True, warp='')
-
-    main.main(args)
+    aroma_workflow(
+        TR=2, affmat=None, denType='nonaggr',
+        dim=0, generate_plots=False, inFeat=None,
+        inFile=nilearn_data.func[0], mask=None,
+        mc=mc_path, melDir=None, outDir=out_path,
+        overwrite=True, warp=None
+    )
 
     # Make sure files are generated
     assert isfile(join(out_path, 'classification_overview.txt'))

--- a/aroma/utils.py
+++ b/aroma/utils.py
@@ -203,7 +203,7 @@ def register2MNI(fslDir, inFile, outFile, affmat, warp):
     # If the no affmat- or warp-file has been specified, assume that the data
     # is already in MNI152 space. In that case only check if resampling to
     # 2mm is needed
-    if (len(affmat) == 0) and (len(warp) == 0):
+    if affmat and warp:
         in_img = nib.load(inFile)
         # Get 3D voxel size
         pixdim1, pixdim2, pixdim3 = in_img.header.get_zooms()[:3]
@@ -222,7 +222,7 @@ def register2MNI(fslDir, inFile, outFile, affmat, warp):
     # If only a warp-file has been specified, assume that the data has already
     # been registered to the structural scan. In that case apply the warping
     # without a affmat
-    elif (len(affmat) == 0) and (len(warp) != 0):
+    elif affmat and warp:
         # Apply warp
         os.system(' '.join([op.join(fslDir, 'applywarp'),
                             '--ref=' + ref,
@@ -233,7 +233,7 @@ def register2MNI(fslDir, inFile, outFile, affmat, warp):
 
     # If only a affmat-file has been specified perform affine registration to
     # MNI
-    elif (len(affmat) != 0) and (len(warp) == 0):
+    elif affmat and warp:
         os.system(' '.join([op.join(fslDir, 'flirt'),
                             '-ref ' + ref,
                             '-in ' + inFile,

--- a/aroma/utils.py
+++ b/aroma/utils.py
@@ -22,9 +22,9 @@ def runICA(fslDir, inFile, outDir, melDirIn, mask, dim, TR):
         should be run
     outDir : str
         Full path of the output directory
-    melDirIn : str
+    melDirIn : str or None
         Full path of the MELODIC directory in case it has been run
-        before, otherwise define empty string
+        before, otherwise None.
     mask : str
         Full path of the mask to be applied during MELODIC
     dim : int
@@ -48,9 +48,9 @@ def runICA(fslDir, inFile, outDir, melDirIn, mask, dim, TR):
     # When a MELODIC directory is specified,
     # check whether all needed files are present.
     # Otherwise... run MELODIC again
-    if (op.isfile(op.join(melDirIn, 'melodic_IC.nii.gz')) and
-            op.isfile(op.join(melDirIn, 'melodic_FTmix')) and
-            op.isfile(op.join(melDirIn, 'melodic_mix'))):
+    if (melDirIn and op.isfile(op.join(melDirIn, 'melodic_IC.nii.gz'))
+            and op.isfile(op.join(melDirIn, 'melodic_FTmix'))
+            and op.isfile(op.join(melDirIn, 'melodic_mix'))):
         print('  - The existing/specified MELODIC directory will be used.')
 
         # If a 'stats' directory is present (contains thresholded spatial maps)
@@ -87,11 +87,11 @@ def runICA(fslDir, inFile, outDir, melDirIn, mask, dim, TR):
         if melDirIn:
             if not op.isdir(melDirIn):
                 print('  - The specified MELODIC directory does not exist. '
-                      'MELODIC will be run seperately.')
+                      'MELODIC will be run separately.')
             else:
                 print('  - The specified MELODIC directory does not contain '
                       'the required files to run ICA-AROMA. MELODIC will be '
-                      'run seperately.')
+                      'run separately.')
 
         # Run MELODIC
         melodic_command = ("{0} --in={1} --outdir={2} --mask={3} --dim={4} "
@@ -203,7 +203,7 @@ def register2MNI(fslDir, inFile, outFile, affmat, warp):
     # If the no affmat- or warp-file has been specified, assume that the data
     # is already in MNI152 space. In that case only check if resampling to
     # 2mm is needed
-    if affmat and warp:
+    if not affmat and not warp:
         in_img = nib.load(inFile)
         # Get 3D voxel size
         pixdim1, pixdim2, pixdim3 = in_img.header.get_zooms()[:3]
@@ -222,7 +222,7 @@ def register2MNI(fslDir, inFile, outFile, affmat, warp):
     # If only a warp-file has been specified, assume that the data has already
     # been registered to the structural scan. In that case apply the warping
     # without a affmat
-    elif affmat and warp:
+    elif not affmat and warp:
         # Apply warp
         os.system(' '.join([op.join(fslDir, 'applywarp'),
                             '--ref=' + ref,
@@ -233,7 +233,7 @@ def register2MNI(fslDir, inFile, outFile, affmat, warp):
 
     # If only a affmat-file has been specified perform affine registration to
     # MNI
-    elif affmat and warp:
+    elif affmat and not warp:
         os.system(' '.join([op.join(fslDir, 'flirt'),
                             '-ref ' + ref,
                             '-in ' + inFile,


### PR DESCRIPTION
Closes #15.

Changes proposed:
- Add functions to support better argument type checks (e.g., existence of file or folder).
- Simplify exceptions in AROMA workflow.
- Use `None` instead of `""` when not providing an argument.