### PR TITLE
[REF] Reduce FSL usage in runICA

### DIFF
--- a/aroma/utils.py
+++ b/aroma/utils.py
@@ -119,7 +119,10 @@ def runICA(fsl_dir, in_file, out_dir, mel_dir_in, mask, dim, TR):
 
         # Get number of volumes in component's thresholded image
         z_temp_img = nib.load(z_temp)
-        len_IC = z_temp_img.shape[4]
+        if z_temp_img.ndim == 4:
+            len_IC = z_temp_img.shape[3]
+        else:
+            len_IC = 1
 
         # Extract last spatial map within the thresh_zstat file
         zstat_img = image.index_img(z_temp, len_IC - 1)

--- a/aroma/utils.py
+++ b/aroma/utils.py
@@ -121,11 +121,11 @@ def runICA(fsl_dir, in_file, out_dir, mel_dir_in, mask, dim, TR):
         z_temp_img = nib.load(z_temp)
         if z_temp_img.ndim == 4:
             len_IC = z_temp_img.shape[3]
+            # Extract last spatial map within the thresh_zstat file
+            zstat_img = image.index_img(z_temp_img, len_IC - 1)
         else:
-            len_IC = 1
+            zstat_img = z_temp_img
 
-        # Extract last spatial map within the thresh_zstat file
-        zstat_img = image.index_img(z_temp, len_IC - 1)
         zstat_imgs.append(zstat_img)
 
     # Merge to 4D

--- a/aroma/utils.py
+++ b/aroma/utils.py
@@ -1,7 +1,6 @@
 """Utility functions for ICA-AROMA."""
 import os
 import os.path as op
-from glob import glob
 
 import nibabel as nib
 import numpy as np

--- a/aroma/utils.py
+++ b/aroma/utils.py
@@ -114,7 +114,7 @@ def runICA(fsl_dir, in_file, out_dir, mel_dir_in, mask, dim, TR):
     zstat_imgs = []
     for i in range(1, nr_ICs + 1):
         # Define thresholded zstat-map file
-        z_temp = op.join(mel_dir, 'stats', 'thresh_zstat{0}.nii.gz'.format(i))
+        z_temp = op.join(mel_dir, "stats", "thresh_zstat{0}.nii.gz".format(i))
 
         # Get number of volumes in component's thresholded image
         z_temp_img = nib.load(z_temp)
@@ -132,7 +132,9 @@ def runICA(fsl_dir, in_file, out_dir, mel_dir_in, mask, dim, TR):
 
     # Apply the mask to the merged image (in case a melodic-directory was
     # predefined and run with a different mask)
-    zstat_4d_img = image.math_img("stat * mask", stat=zstat_4d_img, mask=mask)
+    zstat_4d_img = image.math_img(
+        "stat * mask[:, :, :, None]", stat=zstat_4d_img, mask=mask
+    )
     zstat_4d_img.to_filename(mel_IC_thr)
 
 

--- a/aroma/utils.py
+++ b/aroma/utils.py
@@ -1,11 +1,11 @@
 """Utility functions for ICA-AROMA."""
 import os
 import os.path as op
-import subprocess
 from glob import glob
 
 import nibabel as nib
 import numpy as np
+from nilearn import image
 
 
 def runICA(fsl_dir, in_file, out_dir, mel_dir_in, mask, dim, TR):
@@ -112,53 +112,26 @@ def runICA(fsl_dir, in_file, out_dir, mel_dir_in, mask, dim, TR):
     # mixture modeling did not converge, the file will contain two spatial
     # maps. The latter being the results from a simple null hypothesis test.
     # In that case, this map will have to be used (first one will be empty).
+    zstat_imgs = []
     for i in range(1, nr_ICs + 1):
         # Define thresholded zstat-map file
         z_temp = op.join(mel_dir, 'stats', 'thresh_zstat{0}.nii.gz'.format(i))
-        cmd = "{0} {1} | grep dim4 | head -n1 | awk '{{print $2}}'".format(
-            op.join(fsl_dir, 'fslinfo'),
-            z_temp
-        )
-        len_IC = int(float(subprocess.getoutput(cmd)))
 
-        # Define zeropad for this IC-number and new zstat file
-        cmd = ' '.join([op.join(fsl_dir, 'zeropad'),
-                        str(i),
-                        '4'])
-        IC_num = subprocess.getoutput(cmd)
-        zstat = op.join(out_dir, 'thr_zstat' + IC_num)
+        # Get number of volumes in component's thresholded image
+        z_temp_img = nib.load(z_temp)
+        len_IC = z_temp_img.shape[4]
 
         # Extract last spatial map within the thresh_zstat file
-        os.system(' '.join([op.join(fsl_dir, 'fslroi'),
-                            z_temp,      # input
-                            zstat,      # output
-                            str(len_IC - 1),   # first frame
-                            '1']))      # number of frames
+        zstat_img = image.index_img(z_temp, len_IC - 1)
+        zstat_imgs.append(zstat_img)
 
-    # Merge and subsequently remove all mixture modeled Z-maps within the
-    # output directory
-    merge_command = "{0} -t {1} {2}".format(
-        op.join(fsl_dir, 'fslmerge'),
-        mel_IC_thr,
-        op.join(out_dir, 'thr_zstat????.nii.gz')
-    )
-    os.system(merge_command)  # inputs
+    # Merge to 4D
+    zstat_4d_img = image.concat_imgs(zstat_imgs)
 
-    component_images = glob(
-        op.join(out_dir, 'thr_zstat[0-9][0-9][0-9][0-9].nii.gz')
-    )
-    for f in component_images:
-        os.remove(f)
-
-    # Apply the mask to the merged file (in case a melodic-directory was
+    # Apply the mask to the merged image (in case a melodic-directory was
     # predefined and run with a different mask)
-    math_command = "{0} {1} -mas {2} {3}".format(
-        op.join(fsl_dir, 'fslmaths'),
-        mel_IC_thr,
-        mask,
-        mel_IC_thr,
-    )
-    os.system(math_command)
+    zstat_4d_img = image.math_img("stat * mask", stat=zstat_4d_img, mask=mask)
+    zstat_4d_img.to_filename(mel_IC_thr)
 
 
 def register2MNI(fsl_dir, in_file, out_file, affmat, warp):


### PR DESCRIPTION
<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None, but references #2. This does **not** remove MELODIC as a dependency- it just removes all of the other FSL code from the ICA function.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Replace calls to `fslinfo`, `zeropad`, `fslroi`, `fslmerge`, and `fslmaths` with pure Python `nilearn` and `nibabel` code.
